### PR TITLE
Fix: dotenv import

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,5 @@
 import cookieParser from "cookie-parser";
 import cors from "cors";
-import dotenv from "dotenv";
 import express from "express";
 import mongoSanitize from "express-mongo-sanitize";
 import { xss } from "express-xss-sanitizer";
@@ -13,8 +12,6 @@ import { companiesRouter } from "@/routes/companies";
 import { interviewSessionsRouter } from "@/routes/interviewSessions";
 import { jobListingsRouter } from "@/routes/jobListings";
 import { usersRouter } from "@/routes/users";
-
-dotenv.config();
 
 export const app = express();
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,6 @@
 import cookieParser from "cookie-parser";
 import cors from "cors";
+import dotenv from "dotenv";
 import express from "express";
 import mongoSanitize from "express-mongo-sanitize";
 import { xss } from "express-xss-sanitizer";
@@ -12,6 +13,8 @@ import { companiesRouter } from "@/routes/companies";
 import { interviewSessionsRouter } from "@/routes/interviewSessions";
 import { jobListingsRouter } from "@/routes/jobListings";
 import { usersRouter } from "@/routes/users";
+
+dotenv.config();
 
 export const app = express();
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,8 +1,5 @@
-import dotenv from "dotenv";
 import { app } from "./app";
 import { connectDB } from "./config/db";
-
-dotenv.config();
 
 connectDB();
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,7 @@
+import dotenv from "dotenv";
+
+dotenv.config();
+
 import { app } from "./app";
 import { connectDB } from "./config/db";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -116,5 +116,5 @@
     "tsc-alias": {
         "resolveFullPaths": true
     },
-    "include": ["src/**/*.ts"]
+    "include": ["src/**/*.ts", "tests/**/*.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,7 @@
         // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
         /* Modules */
         "module": "ES6" /* Specify what module code is generated. */,
-        "rootDir": "./src",
+        "rootDir": ".",
         "moduleResolution": "node" /* Specify how TypeScript looks up a file from a given module specifier. */,
         "baseUrl": "." /* Specify the base directory to resolve non-relative module names. */,
         // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */


### PR DESCRIPTION
This pull request includes changes to the `src/app.ts` and `src/server.ts` files to improve the handling of environment variables. The most important changes include importing and configuring `dotenv` in the `src/app.ts` file and removing redundant `dotenv` configuration from the `src/server.ts` file.

Changes to environment variable handling:

* [`src/app.ts`](diffhunk://#diff-841254fe75488c1bd4cd7f68f00b4be0e48dcfbc4a16b45847b68295e0e3b27bR3): Added import for `dotenv` and configured it to load environment variables. [[1]](diffhunk://#diff-841254fe75488c1bd4cd7f68f00b4be0e48dcfbc4a16b45847b68295e0e3b27bR3) [[2]](diffhunk://#diff-841254fe75488c1bd4cd7f68f00b4be0e48dcfbc4a16b45847b68295e0e3b27bR17-R18)
* [`src/server.ts`](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595L1-L6): Removed redundant import and configuration of `dotenv` since it is now handled in `src/app.ts`.